### PR TITLE
fix: restore view radius after crash

### DIFF
--- a/src/main/java/net/nitrado/hytale/plugins/performance_saver/config/RestoreConfig.java
+++ b/src/main/java/net/nitrado/hytale/plugins/performance_saver/config/RestoreConfig.java
@@ -1,0 +1,24 @@
+package net.nitrado.hytale.plugins.performance_saver.config;
+
+import com.hypixel.hytale.codec.Codec;
+import com.hypixel.hytale.codec.KeyedCodec;
+import com.hypixel.hytale.codec.builder.BuilderCodec;
+import com.hypixel.hytale.server.core.HytaleServer;
+
+import java.time.Duration;
+
+public class RestoreConfig {
+    public static final BuilderCodec<RestoreConfig> CODEC = BuilderCodec.builder(RestoreConfig.class, RestoreConfig::new)
+            .append(
+                    new KeyedCodec<>("InitialViewRadius", Codec.INTEGER),
+                    (config, value) -> config.initialViewRadius = value,
+                    config -> config.initialViewRadius
+            ).add()
+            .build();
+
+    private int initialViewRadius = HytaleServer.get().getConfig().getMaxViewRadius();
+
+    public int getInitialViewRadius() {
+        return initialViewRadius;
+    }
+}


### PR DESCRIPTION
Saves the initial view radius to a `restore.json` file and from restores from that file on next start, but deletes it on a clean shutdown.

This protect against a scenario where the server crashes with a limited view radius (which is persisted to the server config.json), and the initial view radius could not be restored during the shutdown.

Closes #3 