### PR TITLE
fix: restore default TPS on shutdown

### DIFF
--- a/src/main/java/net/nitrado/hytale/plugins/performance_saver/PerformanceSaverPlugin.java
+++ b/src/main/java/net/nitrado/hytale/plugins/performance_saver/PerformanceSaverPlugin.java
@@ -242,5 +242,7 @@ public class PerformanceSaverPlugin extends JavaPlugin {
         if (tpsTask != null) {
             this.tpsTask.cancel(false);
         }
+
+        this.tpsAdjuster.restore();
     }
 }

--- a/src/main/java/net/nitrado/hytale/plugins/performance_saver/tps/TpsAdjuster.java
+++ b/src/main/java/net/nitrado/hytale/plugins/performance_saver/tps/TpsAdjuster.java
@@ -61,6 +61,10 @@ public class TpsAdjuster {
         return change;
     }
 
+    public boolean restore() {
+        return this.setTps(World.TPS);
+    }
+
 
     private int getPlayerCount() {
         // Universe.get().getPlayerCount() seems to be faulty


### PR DESCRIPTION
Restores the initial TPS on shutdown, allowing to unload the Plugin at runtime to cleanly revert its changes.