### PR TITLE
build: automatic build on new Hytale server version

### DIFF
--- a/.github/workflows/check-for-new-server-version.yml
+++ b/.github/workflows/check-for-new-server-version.yml
@@ -1,0 +1,13 @@
+name: Check for new Hytale Server version
+
+on:
+  schedule:
+    - cron: '0 */1 * * *'  # every 6 hours
+  workflow_dispatch:         # allow manual triggers
+
+jobs:
+  check:
+    uses: nitrado/hytale-plugin-workflows/.github/workflows/rebuild-on-new-server-version.yml@v2
+    secrets: inherit
+    with:
+      artifact-id: nitrado-performance-saver

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   ci:
-    uses: nitrado/hytale-plugin-workflows/.github/workflows/plugin-ci.yml@v1
+    uses: nitrado/hytale-plugin-workflows/.github/workflows/plugin-ci.yml@v2
     secrets: inherit
     # Optional: override defaults
     # with:

--- a/.github/workflows/curseforge-publish.yml
+++ b/.github/workflows/curseforge-publish.yml
@@ -3,10 +3,18 @@ name: CurseForge Publish
 on:
   workflow_dispatch:
     inputs:
+      version:
+        description: "The semver version string, e.g. 1.0.0+2026.02.19-1a311a592"
+        type: string
+        required: true
+      tag-name:
+        description: "The GitHub release tag name, e.g. v1.0.0"
+        type: string
+        required: true
       game-endpoint:
         description: "The subdomain of curseforge.com"
         type: string
-        default: "authors"
+        default: "42"
       game-versions:
         description: "Game version IDs (comma-separated)"
         type: string
@@ -21,11 +29,13 @@ permissions:
 
 jobs:
   curseforge-publish:
-    uses: nitrado/hytale-plugin-workflows/.github/workflows/curseforge-publish.yml@v1
+    uses: nitrado/hytale-plugin-workflows/.github/workflows/curseforge-publish.yml@v2
     secrets: inherit
     with:
+      artifact-id: "nitrado-performance-saver"
+      version: ${{ inputs.version }}
+      tag-name: ${{ inputs.tag-name }}
       game-endpoint: ${{ inputs.game-endpoint }}
       game-versions: ${{ inputs.game-versions }}
       relations: ${{ inputs.relations }}
-      artifact-id: "nitrado-performance-saver"
 

--- a/.github/workflows/gcs-publish.yml
+++ b/.github/workflows/gcs-publish.yml
@@ -2,13 +2,26 @@ name: GCS Publish
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: "The semver version string, e.g. 1.0.0+2026.02.19-1a311a592"
+        type: string
+        required: true
+      tag-name:
+        description: "The GitHub release tag name, e.g. v1.0.0"
+        type: string
+        required: true
 
 permissions:
   contents: read
 
 jobs:
   gcs-publish:
-    uses: nitrado/hytale-plugin-workflows/.github/workflows/gcs-publish.yml@v1
+    uses: nitrado/hytale-plugin-workflows/.github/workflows/gcs-publish.yml@v2
     secrets: inherit
+    with:
+      artifact-id: "nitrado-performance-saver"
+      version: ${{ inputs.version }}
+      tag-name: ${{ inputs.tag-name }}
 
 

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -3,6 +3,18 @@ name: Maven Publish
 on:
   workflow_dispatch:
     inputs:
+      version:
+        description: "The Maven version to publish, e.g. 1.1.1-rc1"
+        type: string
+        required: true
+      tag-name:
+        description: "The GitHub release tag name, e.g. v1.0.0"
+        type: string
+        required: true
+      hytale-server-version:
+        description: "The Hytale Server version to use for dependency resolution"
+        type: string
+        required: true
       java-version:
         description: "Java version for Maven publishing"
         type: string
@@ -13,8 +25,11 @@ permissions:
 
 jobs:
   maven-publish:
-    uses: nitrado/hytale-plugin-workflows/.github/workflows/maven-publish.yml@v1
+    uses: nitrado/hytale-plugin-workflows/.github/workflows/maven-publish.yml@v2
     secrets: inherit
     with:
+      version: ${{ inputs.version }}
+      tag-name: ${{ inputs.tag-name }}
+      hytale-server-version: ${{ inputs.hytale-server-version }}
       java-version: ${{ inputs.java-version }}
 

--- a/.github/workflows/modtale-publish.yml
+++ b/.github/workflows/modtale-publish.yml
@@ -3,6 +3,14 @@ name: Modtale Publish
 on:
   workflow_dispatch:
     inputs:
+      version:
+        description: "The semver version string, e.g. 1.0.0+2026.02.19-1a311a592"
+        type: string
+        required: true
+      tag-name:
+        description: "The GitHub release tag name, e.g. v1.0.0"
+        type: string
+        required: true
       game-versions:
         description: "Hytale game versions (comma-separated)"
         type: string
@@ -13,8 +21,11 @@ permissions:
 
 jobs:
   modtale-publish:
-    uses: nitrado/hytale-plugin-workflows/.github/workflows/modtale-publish.yml@v1
+    uses: nitrado/hytale-plugin-workflows/.github/workflows/modtale-publish.yml@v2
     secrets: inherit
     with:
+      artifact-id: "nitrado-performance-saver"
+      version: ${{ inputs.version }}
+      tag-name: ${{ inputs.tag-name }}
       game-versions: ${{ inputs.game-versions }}
 


### PR DESCRIPTION
This uses v2 of the shared workflow (https://github.com/nitrado/hytale-plugin-workflows/tree/v2) to automatically build new plugin versions when the server version changes.