### PR TITLE
fix: use proper semver range in manifest.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
   ci:
     uses: nitrado/hytale-plugin-workflows/.github/workflows/plugin-ci.yml@v2
     secrets: inherit
+    with:
+      server-version-range-symbol: "~"
     # Optional: override defaults
     # with:
     #   java-version: "25"


### PR DESCRIPTION
This PR makes use of an upstream fix in https://github.com/nitrado/hytale-plugin-workflows/tree/v2 to not use bare version strings. Instead, we use a range across the minor version.